### PR TITLE
Add weather plugin improvements

### DIFF
--- a/packages/plugin-weather-agent/README.md
+++ b/packages/plugin-weather-agent/README.md
@@ -1,0 +1,123 @@
+# Weather Data Agent Plugin for elizaOS
+
+This plugin integrates a Weather Data Agent with Fetch.ai's Agentverse using Model Context Protocol (MCP).
+
+## Features
+
+- Weather data retrieval via OpenWeatherMap API
+- Integration with Fetch.ai's Agentverse for agent discovery
+- MCP endpoint for standardized context access
+- REST API endpoints for direct weather data access
+
+## Installation
+
+```bash
+# From the eliza root directory
+cd packages/plugin-weather-agent
+npm install
+npm run build
+```
+
+## Configuration
+
+The plugin requires the following environment variables:
+
+- `WEATHER_API_KEY`: Your OpenWeatherMap API key (optional, uses demo mode if not provided)
+- `FETCH_AI_API_KEY`: Your Fetch.ai API key for Agentverse integration (optional)
+
+## Usage
+
+### Enabling the Plugin
+
+To enable this plugin in elizaOS, add it to your configuration:
+
+```javascript
+// In your elizaOS configuration
+{
+  "plugins": [
+    // ... other plugins
+    "@elizaos/plugin-weather-agent"
+  ]
+}
+```
+
+### As an elizaOS Plugin
+
+Once installed and enabled, the plugin provides:
+
+1. A weather service accessible via `runtime.getService('weather')`
+2. A `GET_WEATHER` action for retrieving weather data
+3. A weather provider that responds to natural language queries about weather
+
+Example usage:
+```javascript
+// Using the GET_WEATHER action
+const result = await runtime.executeAction('GET_WEATHER', { location: 'London' });
+
+// Using the weather service directly
+const weatherService = runtime.getService('weather');
+const weatherData = await weatherService.getWeatherData('Tokyo');
+```
+
+### REST API
+
+The plugin exposes the following endpoints:
+
+- `GET /weather?location=CityName`: Get weather data for a specific location
+- `POST /weather/mcp`: MCP-compatible endpoint for weather data requests
+
+## Implementation Status
+
+### Fetch.ai Integration (INCOMPLETE)
+
+The current implementation includes placeholders for Fetch.ai registration:
+
+- `registerWithFetchAi()` is a stub and does not use the uAgents SDK
+- No real communication with Fetch.ai's Agentverse occurs
+- Registration is simulated and always succeeds
+
+To fully integrate Fetch.ai you would need to:
+1. Install the uAgents SDK
+2. Implement registration and discovery APIs
+3. Handle messaging between agents
+
+### MCP Integration (INCOMPLETE)
+
+The Model Context Protocol (MCP) connector provided here is also simplified:
+
+- The `/weather/mcp` endpoint accepts requests but only implements a subset of the MCP standard
+- Request and response schemas are not validated
+- Additional MCP operations are not supported
+
+To finish the MCP implementation you would need to:
+1. Implement full MCP schemas and validation
+2. Support all required MCP metadata and operations
+3. Ensure compatibility with future MCP tooling
+
+## Fetch.ai Integration
+
+This plugin demonstrates integration with Fetch.ai's Agentverse by:
+
+1. Implementing a compatible agent structure
+2. Providing registration with the Agentverse ecosystem
+3. Supporting agent discovery and communication
+
+## Development
+
+```bash
+# Run in development mode
+npm run dev
+
+# Run tests
+npm run test
+```
+
+## Known Limitations
+
+- The Fetch.ai integration is currently a placeholder and requires the uAgents SDK for full functionality
+- Weather data is retrieved from OpenWeatherMap API, which requires an API key for production use
+- The MCP implementation is a simplified version of the full protocol
+
+## License
+
+See the elizaOS license for details.

--- a/packages/plugin-weather-agent/__tests__/utils/mockServer.ts
+++ b/packages/plugin-weather-agent/__tests__/utils/mockServer.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import supertest from 'supertest';
+import { Plugin, IAgentRuntime } from '@elizaos/core';
+
+/**
+ * Creates a mock Express server with the plugin's routes for testing
+ *
+ * @param plugin The plugin containing routes to test
+ * @param runtime Mock runtime to pass to route handlers
+ * @returns Object containing Express app and supertest instance
+ */
+export function createMockServer(plugin: Plugin, runtime: IAgentRuntime) {
+  const app = express();
+  app.use(express.json());
+
+  if (typeof plugin.routes === 'function') {
+    const routes = plugin.routes(runtime);
+    routes.forEach(route => {
+      const method = route.type.toLowerCase();
+      if (method === 'get') {
+        app.get(route.path, route.handler as any);
+      } else if (method === 'post') {
+        app.post(route.path, route.handler as any);
+      } else if (method === 'put') {
+        app.put(route.path, route.handler as any);
+      } else if (method === 'delete') {
+        app.delete(route.path, route.handler as any);
+      }
+    });
+  }
+
+  return {
+    app,
+    supertest: supertest(app),
+  };
+}

--- a/packages/plugin-weather-agent/__tests__/weather-agent.test.ts
+++ b/packages/plugin-weather-agent/__tests__/weather-agent.test.ts
@@ -1,0 +1,210 @@
+import { expect, vi, describe, test, beforeEach } from 'vitest';
+import { weatherPlugin, WeatherService, getWeatherAction, weatherProvider, WeatherMCPConnector } from '../src';
+import axios from 'axios';
+import { createMockServer } from './utils/mockServer';
+
+// Mock axios
+vi.mock('axios');
+
+// Sample weather data response
+const mockWeatherData = {
+  name: 'London',
+  sys: {
+    country: 'GB'
+  },
+  main: {
+    temp: 15.5,
+    humidity: 76
+  },
+  weather: [
+    {
+      description: 'partly cloudy'
+    }
+  ],
+  wind: {
+    speed: 4.2
+  }
+};
+
+// Mock runtime for testing
+const mockRuntime = {
+  getService: vi.fn((name) => {
+    if (name === 'weather') {
+      return new WeatherService(mockRuntime as any);
+    }
+    return null;
+  }),
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
+} as any;
+
+describe('Weather Agent Plugin Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Setup axios mock
+    (axios.get as any).mockResolvedValue({ data: mockWeatherData });
+  });
+
+  test('Plugin should have correct name and description', () => {
+    expect(weatherPlugin.name).toBe('plugin-weather-agent');
+    expect(weatherPlugin.description).toContain('Weather Data Agent');
+  });
+
+  test('Plugin should have weather service registered', () => {
+    const hasWeatherService = weatherPlugin.services.some(
+      (service) => service.serviceType === 'weather'
+    );
+    expect(hasWeatherService).toBe(true);
+  });
+
+  test('Plugin should have GET_WEATHER action registered', () => {
+    const hasGetWeatherAction = weatherPlugin.actions.some(
+      (action) => action.name === 'GET_WEATHER'
+    );
+    expect(hasGetWeatherAction).toBe(true);
+  });
+
+  test('Plugin should have weather provider registered', () => {
+    const hasWeatherProvider = weatherPlugin.providers.some(
+      (provider) => provider.name === 'weather'
+    );
+    expect(hasWeatherProvider).toBe(true);
+  });
+
+  test('Plugin should have routes function that returns weather routes', () => {
+    expect(typeof weatherPlugin.routes).toBe('function');
+    const routes = (weatherPlugin.routes as any)(mockRuntime);
+    
+    const hasWeatherRoute = routes.some(
+      (route: any) => route.path === '/weather'
+    );
+    const hasMcpRoute = routes.some(
+      (route: any) => route.path === '/weather/mcp'
+    );
+    
+    expect(hasWeatherRoute).toBe(true);
+    expect(hasMcpRoute).toBe(true);
+  });
+
+  test('WeatherService should fetch weather data correctly', async () => {
+    const weatherService = new WeatherService(mockRuntime as any);
+    const result = await weatherService.getWeatherData('London');
+    
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining('London')
+    );
+    expect(result).toEqual(mockWeatherData);
+  });
+
+  test('GET_WEATHER action should return weather data', async () => {
+    const result = await getWeatherAction.handler(mockRuntime as any, { location: 'London' });
+    
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveProperty('location', 'London');
+    expect(result.data).toHaveProperty('temperature', 15.5);
+  });
+
+  test('Weather provider should extract location and return weather data', async () => {
+    const result = await weatherProvider.handler(
+      mockRuntime as any,
+      { text: 'What is the weather in London?' } as any,
+      {} as any
+    );
+    
+    expect(result.text).toContain('London');
+    expect(result.text).toContain('15.5°C');
+    expect(result.values).toHaveProperty('location', 'London');
+  });
+
+  test('MCP connector should handle requests correctly', async () => {
+    const mcpConnector = new WeatherMCPConnector(mockRuntime as any);
+    const result = await mcpConnector.handleMCPRequest({ location: 'London' });
+    
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(mockWeatherData);
+  });
+
+  test('Error handling in weather service', async () => {
+    (axios.get as any).mockRejectedValueOnce(new Error('API error'));
+
+    const weatherService = new WeatherService(mockRuntime as any);
+    await expect(weatherService.getWeatherData('London')).rejects.toThrow('Failed to fetch weather data');
+  });
+});
+
+// HTTP Endpoint Tests
+describe('Weather Agent HTTP Endpoint Tests', () => {
+  let server: any;
+  let request: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (axios.get as any).mockResolvedValue({ data: mockWeatherData });
+
+    const { app, supertest } = createMockServer(weatherPlugin as any, mockRuntime as any);
+    server = app;
+    request = supertest;
+  });
+
+  test('GET /weather should return weather data for valid location', async () => {
+    const response = await request.get('/weather?location=London');
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toEqual(mockWeatherData);
+  });
+
+  test('GET /weather should return 400 when location is missing', async () => {
+    const response = await request.get('/weather');
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('Location parameter is required');
+  });
+
+  test('GET /weather should return 500 when weather service fails', async () => {
+    (axios.get as any).mockRejectedValueOnce(new Error('API error'));
+
+    const response = await request.get('/weather?location=London');
+
+    expect(response.status).toBe(500);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('Failed to get weather data');
+  });
+
+  test('POST /weather/mcp should handle valid MCP requests', async () => {
+    const response = await request
+      .post('/weather/mcp')
+      .send({ location: 'London' })
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toEqual(mockWeatherData);
+  });
+
+  test('POST /weather/mcp should return error when location is missing', async () => {
+    const response = await request
+      .post('/weather/mcp')
+      .send({})
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(200);
+    expect(response.body.error).toContain('Location is required');
+  });
+
+  test('POST /weather/mcp should handle service errors', async () => {
+    (axios.get as any).mockRejectedValueOnce(new Error('API error'));
+
+    const response = await request
+      .post('/weather/mcp')
+      .send({ location: 'London' })
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toContain('Failed to process MCP request');
+  });
+});

--- a/packages/plugin-weather-agent/package.json
+++ b/packages/plugin-weather-agent/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@elizaos/plugin-weather-agent",
+  "description": "Weather Data Agent with Fetch.ai integration for elizaOS",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "keywords": [
+    "plugin",
+    "elizaos",
+    "weather",
+    "fetch.ai",
+    "mcp",
+    "agent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elizaOS/eliza"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@elizaos/cli": "^1.0.0-beta.41",
+    "@elizaos/core": "^1.0.0-beta.41",
+    "axios": "^1.6.0",
+    "zod": "3.24.1"
+  },
+  "devDependencies": {
+    "express": "^4.18.2",
+    "supertest": "^6.3.3",
+    "tsup": "8.4.0",
+    "typescript": "5.8.2",
+    "prettier": "3.5.3",
+    "vitest": "^1.0.0"
+  },
+  "scripts": {
+    "start": "elizaos start",
+    "test-with-cli": "cd ../cli && bun run build && cd ../plugin-weather-agent && elizaos test",
+    "dev": "elizaos dev",
+    "build": "tsup",
+    "lint": "prettier --write ./src",
+    "test": "vitest run",
+    "publish": "elizaos publish",
+    "format": "prettier --write ./src",
+    "format:check": "prettier --check ./src"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "resolutions": {
+    "zod": "3.24.1"
+  }
+}

--- a/packages/plugin-weather-agent/src/index.ts
+++ b/packages/plugin-weather-agent/src/index.ts
@@ -1,0 +1,377 @@
+import { z } from 'zod';
+import {
+  IAgentRuntime,
+  Plugin,
+  Service,
+  logger,
+  ModelType,
+  GenerateTextParams,
+  ProviderResult,
+  Memory,
+  State,
+  Action,
+} from '@elizaos/core';
+import axios from 'axios';
+
+// Configuration schema for the weather agent plugin
+const configSchema = z.object({
+  WEATHER_API_KEY: z.string().optional(),
+  FETCH_AI_API_KEY: z.string().optional(),
+});
+
+// Weather service that handles API calls and data processing
+export class WeatherService extends Service {
+  static serviceType = 'weather';
+  capabilityDescription = 'This service provides weather data through Fetch.ai integration using MCP.';
+  
+  constructor(protected runtime: IAgentRuntime) {
+    super(runtime);
+    logger.info('Weather service initialized');
+  }
+
+  static async start(runtime: IAgentRuntime) {
+    logger.info(`Starting weather service - ${new Date().toISOString()}`);
+    const service = new WeatherService(runtime);
+    return service;
+  }
+
+  static async stop(runtime: IAgentRuntime) {
+    logger.info('Stopping weather service');
+    const service = runtime.getService(WeatherService.serviceType);
+    if (!service) {
+      throw new Error('Weather service not found');
+    }
+    service.stop();
+  }
+
+  async stop() {
+    logger.info('Weather service stopped');
+  }
+
+  // Method to get weather data from API
+  async getWeatherData(location: string): Promise<any> {
+    try {
+      // Using a free weather API for demonstration
+      const apiKey = process.env.WEATHER_API_KEY || 'demo';
+      const response = await axios.get(
+        `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(location)}&appid=${apiKey}&units=metric`
+      );
+      return response.data;
+    } catch (error) {
+      logger.error('Error fetching weather data:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Failed to fetch weather data: ${errorMessage}`);
+    }
+  }
+
+  // Method to register agent with Fetch.ai Agentverse
+  // NOTE: This is a placeholder for actual Fetch.ai registration
+  // In a real implementation, this would use the uAgents SDK
+  async registerWithFetchAi(): Promise<boolean> {
+    try {
+      logger.info('Registering agent with Fetch.ai Agentverse');
+      
+      // TODO: Implement actual Fetch.ai registration using uAgents SDK
+      // This is currently a placeholder that simulates successful registration
+      
+      return true;
+    } catch (error) {
+      logger.error('Error registering with Fetch.ai:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Failed to register with Fetch.ai: ${errorMessage}`);
+    }
+  }
+}
+
+// Action to get weather for a location
+export const getWeatherAction: Action = {
+  name: 'GET_WEATHER',
+  description: 'Get weather information for a specific location',
+  parameters: {
+    location: {
+      type: 'string',
+      description: 'The city or location to get weather for',
+      required: true,
+    },
+  },
+  handler: async (runtime, params) => {
+    const { location } = params;
+    if (!location) {
+      return {
+        success: false,
+        error: 'Location is required',
+      };
+    }
+
+    try {
+      const weatherService = runtime.getService('weather') as WeatherService;
+      if (!weatherService) {
+        throw new Error('Weather service not available');
+      }
+
+      const weatherData = await weatherService.getWeatherData(location);
+      
+      return {
+        success: true,
+        data: {
+          location: weatherData.name,
+          country: weatherData.sys.country,
+          temperature: weatherData.main.temp,
+          description: weatherData.weather[0].description,
+          humidity: weatherData.main.humidity,
+          windSpeed: weatherData.wind.speed,
+        },
+      };
+    } catch (error) {
+      logger.error('Error in GET_WEATHER action:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to get weather: ${errorMessage}`,
+      };
+    }
+  },
+};
+
+// Provider for weather information
+export const weatherProvider = {
+  name: 'weather',
+  description: 'Provides weather information for a location',
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state: State
+  ): Promise<ProviderResult> => {
+    // Extract location from message or state
+    const locationMatch = message.text.match(/weather (?:for|in|at) ([a-zA-Z\s]+)/i);
+    const location = locationMatch ? locationMatch[1].trim() : null;
+
+    if (!location) {
+      return {
+        text: 'I need a location to provide weather information. Try asking about the weather in a specific city.',
+        values: {},
+        data: {},
+      };
+    }
+
+    try {
+      const weatherService = runtime.getService('weather') as WeatherService;
+      if (!weatherService) {
+        throw new Error('Weather service not available');
+      }
+
+      const weatherData = await weatherService.getWeatherData(location);
+      
+      return {
+        text: `The current weather in ${weatherData.name}, ${weatherData.sys.country} is ${weatherData.weather[0].description} with a temperature of ${weatherData.main.temp}°C, humidity at ${weatherData.main.humidity}%, and wind speed of ${weatherData.wind.speed} m/s.`,
+        values: {
+          location: weatherData.name,
+          country: weatherData.sys.country,
+          temperature: weatherData.main.temp,
+          description: weatherData.weather[0].description,
+        },
+        data: {
+          weather: weatherData,
+        },
+      };
+    } catch (error) {
+      logger.error('Error in weather provider:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        text: `I'm sorry, I couldn't get the weather information for ${location}. Please try again later.`,
+        values: {},
+        data: {},
+      };
+    }
+  },
+};
+
+// MCP integration for weather data
+export class WeatherMCPConnector {
+  private runtime: IAgentRuntime;
+  
+  constructor(runtime: IAgentRuntime) {
+    this.runtime = runtime;
+    logger.info('Weather MCP connector initialized');
+  }
+
+  // Method to handle MCP requests for weather data
+  async handleMCPRequest(request: any): Promise<any> {
+    try {
+      const { location } = request;
+      if (!location) {
+        return {
+          error: 'Location is required for weather data',
+        };
+      }
+
+      const weatherService = this.runtime.getService('weather') as WeatherService;
+      if (!weatherService) {
+        throw new Error('Weather service not available');
+      }
+
+      const weatherData = await weatherService.getWeatherData(location);
+      return {
+        success: true,
+        data: weatherData,
+      };
+    } catch (error) {
+      logger.error('Error handling MCP request:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        error: `Failed to process MCP request: ${errorMessage}`,
+      };
+    }
+  }
+}
+
+// Create a closure with runtime for route handlers
+const createRouteHandlers = (runtime: IAgentRuntime) => {
+  // Weather API endpoint handler
+  const weatherHandler = async (_req: any, res: any) => {
+    const location = _req.query.location;
+    if (!location) {
+      return res.status(400).json({
+        error: 'Location parameter is required',
+      });
+    }
+
+    try {
+      const weatherService = runtime.getService('weather') as WeatherService;
+      if (!weatherService) {
+        throw new Error('Weather service not available');
+      }
+
+      const weatherData = await weatherService.getWeatherData(location);
+      res.json({
+        success: true,
+        data: weatherData,
+      });
+    } catch (error) {
+      logger.error('Error in /weather endpoint:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      res.status(500).json({
+        success: false,
+        error: `Failed to get weather data: ${errorMessage}`,
+      });
+    }
+  };
+
+  // MCP endpoint handler
+  const mcpHandler = async (_req: any, res: any) => {
+    try {
+      const mcpConnector = new WeatherMCPConnector(runtime);
+      const result = await mcpConnector.handleMCPRequest(_req.body);
+      res.json(result);
+    } catch (error) {
+      logger.error('Error in /weather/mcp endpoint:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      res.status(500).json({
+        success: false,
+        error: `Failed to process MCP request: ${errorMessage}`,
+      });
+    }
+  };
+
+  return {
+    weatherHandler,
+    mcpHandler,
+  };
+};
+
+// Main plugin definition
+export const weatherPlugin: Plugin = {
+  name: 'plugin-weather-agent',
+  description: 'Weather Data Agent with Fetch.ai integration for elizaOS',
+  config: {
+    WEATHER_API_KEY: process.env.WEATHER_API_KEY,
+    FETCH_AI_API_KEY: process.env.FETCH_AI_API_KEY,
+  },
+  async init(config: Record<string, string>) {
+    logger.info('Initializing weather agent plugin');
+    try {
+      const validatedConfig = await configSchema.parseAsync(config);
+      // Set environment variables
+      for (const [key, value] of Object.entries(validatedConfig)) {
+        if (value) process.env[key] = value;
+      }
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new Error(
+          `Invalid plugin configuration: ${error.errors.map((e) => e.message).join(', ')}`
+        );
+      }
+      throw error;
+    }
+  },
+  models: {
+    [ModelType.TEXT_SMALL]: async (
+      runtime,
+      { prompt, stopSequences = [] }: GenerateTextParams
+    ) => {
+      // Simple response for demonstration
+      if (prompt.toLowerCase().includes('weather')) {
+        return 'I can help you get weather information for any location. Just ask about the weather in a specific city.';
+      }
+      return 'I am a weather agent that can provide weather information through Fetch.ai integration.';
+    },
+  },
+  tests: [
+    {
+      name: 'weather_agent_test_suite',
+      tests: [
+        {
+          name: 'service_availability_test',
+          fn: async (runtime) => {
+            logger.debug('Testing weather service availability');
+            const service = runtime.getService('weather');
+            if (!service) {
+              throw new Error('Weather service not found');
+            }
+          },
+        },
+        {
+          name: 'weather_action_test',
+          fn: async (runtime) => {
+            logger.debug('Testing weather action registration');
+            const actionExists = weatherPlugin.actions.some((a) => a.name === 'GET_WEATHER');
+            if (!actionExists) {
+              throw new Error('GET_WEATHER action not found in plugin');
+            }
+          },
+        },
+      ],
+    },
+  ],
+  routes: (runtime) => {
+    const { weatherHandler, mcpHandler } = createRouteHandlers(runtime);
+    
+    return [
+      {
+        path: '/weather',
+        type: 'GET',
+        handler: weatherHandler,
+      },
+      {
+        path: '/weather/mcp',
+        type: 'POST',
+        handler: mcpHandler,
+      },
+    ];
+  },
+  events: {
+    MESSAGE_RECEIVED: [
+      async (params) => {
+        if (params.message?.text?.toLowerCase().includes('weather')) {
+          logger.debug('Weather-related message received');
+        }
+      },
+    ],
+  },
+  services: [WeatherService],
+  actions: [getWeatherAction],
+  providers: [weatherProvider],
+};
+
+export default weatherPlugin;

--- a/packages/plugin-weather-agent/tsconfig.build.json
+++ b/packages/plugin-weather-agent/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugin-weather-agent/tsconfig.json
+++ b/packages/plugin-weather-agent/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": false,
+    "allowImportingTsExtensions": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": false,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmitOnError": false,
+    "moduleDetection": "force",
+    "allowArbitraryExtensions": true,
+    "baseUrl": ".",
+    "paths": {
+      "@elizaos/core": ["../core/src"],
+      "@elizaos/core/*": ["../core/src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/plugin-weather-agent/tsup.config.ts
+++ b/packages/plugin-weather-agent/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  outDir: 'dist',
+  tsconfig: './tsconfig.build.json',
+  sourcemap: true,
+  clean: true,
+  format: ['esm'],
+  dts: true,
+  external: [
+    'dotenv',
+    'fs',
+    'path',
+    'https',
+    'http',
+    '@elizaos/core',
+    'zod',
+  ],
+});

--- a/packages/plugin-weather-agent/vitest.config.ts
+++ b/packages/plugin-weather-agent/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+  },
+});


### PR DESCRIPTION
## Summary
- clarify placeholder sections in README for plugin-weather-agent
- add express test server utility
- expand plugin-weather-agent tests for HTTP endpoints
- include express & supertest for testing
- externalize @elizaos/core in plugin build config

## Testing
- `npm test` *(fails: vitest not found)*